### PR TITLE
BUG: Remove usage of ITK_USE_FILE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,6 @@ project(FixedPointInverseDeformationField)
 
 if(NOT ITK_SOURCE_DIR)
   find_package(ITK 4.9 REQUIRED)
-  include(${ITK_USE_FILE})
   list(APPEND CMAKE_MODULE_PATH ${ITK_CMAKE_DIR})
   include(ITKModuleExternal)
 else()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 itk_module_test()
 
-CreateTestDriver(FixedPointInverseDeformationField "${InverseDeformationField-Test_LIBRARIES}" "FixedPointInverseDeformationFieldTest.cxx")
+CreateTestDriver(FixedPointInverseDeformationField "${FixedPointInverseDeformationField-Test_LIBRARIES}" "FixedPointInverseDeformationFieldTest.cxx")
 
 set(FixedPointInverseDeformationFieldTestTestDriverOutput ${ITK_TEST_OUTPUT_DIR}/InverseDeformationField.nii.gz)
 


### PR DESCRIPTION
ITK_USE_FILE should not be included as it creates an IO
header file that does not match the list of IO provided
by the module test libraries.
